### PR TITLE
Advanced OTPification

### DIFF
--- a/src/farwest.app.src
+++ b/src/farwest.app.src
@@ -22,5 +22,7 @@
 		stdlib
 	]},
 	{mod, {farwest_app, []}},
-	{env, []}
+	{env, [
+		{port, 8080}
+	]}
 ]}.

--- a/src/farwest.app.src
+++ b/src/farwest.app.src
@@ -29,5 +29,8 @@
 	{mod, {farwest_app, []}},
 	{env, [
 		{port, 8080}
+	]},
+	{start_phases, [
+		{listen, []}
 	]}
 ]}.

--- a/src/farwest.app.src
+++ b/src/farwest.app.src
@@ -19,7 +19,12 @@
 	{registered, [farwest_sup]},
 	{applications, [
 		kernel,
-		stdlib
+		stdlib,
+		lager,
+		gproc,
+		jsx,
+		erlydtl,
+		cowboy
 	]},
 	{mod, {farwest_app, []}},
 	{env, [

--- a/src/farwest.erl
+++ b/src/farwest.erl
@@ -22,9 +22,15 @@
 %% @doc Start Farwest and all its dependencies.
 -spec start() -> ok.
 start() ->
-	ok = application:start(compiler),
-	ok = application:start(syntax_tools),
-	ok = application:start(lager),
-	ok = application:start(gproc),
-	ok = application:start(cowboy),
-	ok = application:start(farwest).
+	a_start(farwest, permanent).
+
+a_start(App, Type) ->
+	start_ok(App, Type, application:start(App, Type)).
+
+start_ok(_App, _Type, ok) -> ok;
+start_ok(_App, _Type, {error, {already_started, _App}}) -> ok;
+start_ok(App, Type, {error, {not_started, Dep}}) ->
+	ok = a_start(Dep, Type),
+	a_start(App, Type);
+start_ok(App, _Type, {error, Reason}) ->
+	erlang:error({app_start_failed, App, Reason}).

--- a/src/farwest_app.erl
+++ b/src/farwest_app.erl
@@ -28,10 +28,7 @@ start(_, _) ->
 		{ok, PD} -> PD
 	end,
 	{ok, Dispatch} = file:consult(PrivDir ++ "/dispatch.conf"),
-	Port = case application:get_env(farwest, port) of
-		{ok, P} -> P;
-		undefined -> 8080
-	end,
+	{ok, Port} = application:get_env(farwest, port),
 	{ok, _} = cowboy:start_listener(farwest, 100,
 		cowboy_tcp_transport, [{port, Port}],
 		cowboy_http_protocol, [{dispatch, Dispatch}]

--- a/src/farwest_app.erl
+++ b/src/farwest_app.erl
@@ -24,6 +24,9 @@
 
 %% The priv_dir environment setting is mandatory.
 start(_, _) ->
+	farwest_sup:start_link().
+
+start_phase(listen, _, _) ->
 	PrivDir = case application:get_env(farwest, priv_dir) of
 		{ok, PD} -> PD
 	end,
@@ -34,7 +37,7 @@ start(_, _) ->
 		cowboy_http_protocol, [{dispatch, Dispatch}]
 	),
 	lager:info("Farwest listening on port ~p~n", [Port]),
-	farwest_sup:start_link().
+	ok.
 
 stop(_) ->
 	ok.


### PR DESCRIPTION
- Adds a listen start phase to allow the children of the top level supervisor to start before the application accepts http clients.
- Adds runtime dependency information to the farwest.app.src file and uses this information dynamically at start time to avoid maintaining duplicate sets OTP dependency information.
- Makes the http listen port an OTP environment variable with a default that can be overridden.
